### PR TITLE
Improve Encar API parsing and frontend resilience

### DIFF
--- a/api/encar.ts
+++ b/api/encar.ts
@@ -8,14 +8,61 @@ export interface EncarData {
   img?: string
 }
 
-function parse(html: string): EncarData {
-  const get = (re: RegExp) => {
-    const m = html.match(re)
-    return m ? m[1] : undefined
+function toNum(v: any): number {
+  if (typeof v === 'number') return v
+  if (typeof v === 'string') {
+    const n = Number(v.replace(/[^\d.]/g, ''))
+    return isFinite(n) ? n : 0
   }
-  const priceKrw = Number(get(/"price"\s*:\s*(\d+)/))
-  const year = Number(get(/"year"\s*:\s*(\d{4})/))
-  const fuelRaw = get(/"fuelType"\s*:\s*"(\w+)"/i) || ''
+  return 0
+}
+
+function parse(html: string): EncarData {
+  const jsons: any[] = []
+  const addJson = (s?: string) => {
+    if (!s) return
+    try {
+      jsons.push(JSON.parse(s))
+    } catch {}
+  }
+
+  for (const m of html.matchAll(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi)) {
+    addJson(m[1])
+  }
+  for (const m of html.matchAll(/<script[^>]*>([\s\S]*?)<\/script>/gi)) {
+    const txt = m[1]
+    const m1 = txt.match(/window.__INITIAL_STATE__\s*=\s*(\{[\s\S]*?\});/)
+    if (m1) addJson(m1[1])
+    const m2 = txt.match(/__NUXT__\s*=\s*(\{[\s\S]*?\});/)
+    if (m2) addJson(m2[1])
+  }
+
+  const pick = (...paths: string[][]): any => {
+    for (const p of paths) {
+      for (const j of jsons) {
+        let v: any = j
+        for (const k of p) v = v?.[k]
+        if (v !== undefined) return v
+      }
+    }
+    return undefined
+  }
+
+  let priceKrw = toNum(pick(['price'], ['offers', 'price']))
+  let year = toNum(pick(['year'], ['productionDate']))
+  let fuelRaw = (pick(['fuelType'], ['fuel'], ['vehicleEngine', 'fuelType']) || '') as string
+  let displacementCc = toNum(pick(['displacement'], ['vehicleEngine', 'displacement']))
+  let powerHp = toNum(pick(['power'], ['vehicleEngine', 'power'], ['power', 'value']))
+
+  if (!priceKrw) {
+    const nums = [...html.matchAll(/([\d.,]+)\s*원/g)].map((m) => toNum(m[1])).filter((n) => n >= 100_000 && n <= 500_000_000)
+    if (nums.length) priceKrw = Math.max(...nums)
+  }
+  if (!year) {
+    const years = [...html.matchAll(/(20\d{2})/g)].map((m) => Number(m[1])).filter((n) => n >= 2005 && n <= 2025)
+    if (years.length) year = Math.max(...years)
+  }
+
   const map: Record<string, EncarData['engineType']> = {
     gasoline: 'petrol',
     petrol: 'petrol',
@@ -24,22 +71,37 @@ function parse(html: string): EncarData {
     electric: 'ev',
     ev: 'ev',
   }
-  const engineType = map[fuelRaw.toLowerCase()] || 'petrol'
-  const displacementCc = Number(get(/"displacement"\s*:\s*(\d+)/)) || undefined
-  const powerHp = Number(get(/"power"\s*:\s*(\d+)/)) || undefined
-  const title = get(/<meta property="og:title" content="([^"]+)"/i)
-  const img = get(/<meta property="og:image" content="([^"]+)"/i)
-  return { priceKrw, year, engineType, displacementCc, powerHp, title, img }
+
+  let engineType = map[fuelRaw.toLowerCase()]
+  if (!engineType) {
+    if (/디젤|diesel/i.test(html)) engineType = 'diesel'
+    else if (/하이브리드|hybrid/i.test(html)) engineType = 'hybrid'
+    else if (/전기|electric|ev/i.test(html)) engineType = 'ev'
+    else engineType = 'petrol'
+  }
+
+  const title = html.match(/<meta property="og:title" content="([^"]+)"/i)?.[1]
+  const img = html.match(/<meta property="og:image" content="([^"]+)"/i)?.[1]
+
+  return {
+    priceKrw,
+    year,
+    engineType,
+    displacementCc: displacementCc || undefined,
+    powerHp: powerHp || undefined,
+    title,
+    img,
+  }
 }
 
 export default {
   async fetch(req: Request): Promise<Response> {
     const url = new URL(req.url)
-    const target = url.searchParams.get('url') || ''
+    let target = url.searchParams.get('url') || ''
     const headers = {
       'Content-Type': 'application/json',
       'Access-Control-Allow-Origin': '*',
-      'Cache-Control': 'public, max-age=600',
+      Vary: 'Origin',
     }
     if (!/^https?:\/\/[^/]*encar\.com/i.test(target)) {
       return new Response(JSON.stringify({ ok: false, error: 'invalid url' }), {
@@ -47,16 +109,33 @@ export default {
         headers,
       })
     }
+    target = target.replace(/^https?:\/\//, '')
+    target = target.replace(/^(fem|m)\./, 'www.')
+    target = 'https://' + target
+
+    const UA =
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 ' +
+      'Chrome/124 Safari/537.36'
+
     try {
-      const res = await fetch(target, { headers: { 'user-agent': 'Mozilla/5.0' } })
-      const html = await res.text()
+      let html = ''
+      try {
+        const resp = await fetch(target, { headers: { 'user-agent': UA } })
+        if (!resp.ok) throw new Error('direct fetch ' + resp.status)
+        html = await resp.text()
+      } catch {
+        const proxied = 'https://r.jina.ai/http://' + target.replace(/^https?:\/\//, '')
+        const resp2 = await fetch(proxied, { headers: { 'user-agent': UA } })
+        html = await resp2.text()
+      }
       const data = parse(html)
+      if (!data.priceKrw || !data.year) throw new Error('parse failed')
       return new Response(JSON.stringify({ ok: true, data }), { headers })
     } catch (e: any) {
-      return new Response(JSON.stringify({ ok: false, error: 'fetch failed' }), {
-        status: 500,
-        headers,
-      })
+      return new Response(
+        JSON.stringify({ ok: false, error: e.message || 'fetch failed' }),
+        { status: 500, headers },
+      )
     }
   },
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,18 +53,18 @@ export default function App() {
   const handleCalc = async () => {
     setError(null)
     try {
-      const encarUrl = `/api/encar?url=${encodeURIComponent(state.url)}`
-      const [encarRes, krwRate, usdRate] = await Promise.all([
-        fetch(encarUrl).then((r) => r.json()),
+      const apiUrl = `/api/encar?url=${encodeURIComponent(state.url)}`
+      const [resp, krwUsd, usdRub] = await Promise.all([
+        fetch(apiUrl),
         fetchKrwToUsd(),
         fetchUsdToRub(),
       ])
-      if (!encarRes.ok) throw new Error(encarRes.error || 'parse failed')
-      const data: EncarData = encarRes.data
-      const priceKrw = data.priceKrw
-      const krwUsd = krwRate
-      const usdRub = usdRate
-      const priceUsd = calcPriceUsd(priceKrw, krwUsd)
+      const raw = await resp.text()
+      console.log('API status:', resp.status, 'raw:', raw.slice(0, 200))
+      const enc = JSON.parse(raw)
+      if (!enc.ok || !enc.data?.priceKrw) throw new Error(enc.error || 'No price')
+      const data: EncarData = enc.data
+      const priceUsd = calcPriceUsd(data.priceKrw, krwUsd)
       const customsRes = calcCustoms({
         year: data.year,
         engineType: data.engineType,

--- a/src/lib/rates.ts
+++ b/src/lib/rates.ts
@@ -1,23 +1,15 @@
 export async function fetchKrwToUsd(): Promise<number> {
   try {
-    const r = await fetch('https://api.exchangerate.host/latest?base=KRW&symbols=USD', { cache: 'no-store' });
-    if (!r.ok) throw 0;
-    const j = await r.json();
-    const v = j?.rates?.USD;
+    const r = await fetch('https://api.exchangerate.host/latest?base=KRW&symbols=USD');
+    const j = await r.json(); const v = j?.rates?.USD;
     return typeof v === 'number' && isFinite(v) ? v : 0.00074;
-  } catch {
-    return 0.00074;
-  }
+  } catch { return 0.00074; }
 }
 
 export async function fetchUsdToRub(): Promise<number> {
   try {
-    const r = await fetch('https://api.exchangerate.host/latest?base=USD&symbols=RUB', { cache: 'no-store' });
-    if (!r.ok) throw 0;
-    const j = await r.json();
-    const v = j?.rates?.RUB;
+    const r = await fetch('https://api.exchangerate.host/latest?base=USD&symbols=RUB');
+    const j = await r.json(); const v = j?.rates?.RUB;
     return typeof v === 'number' && isFinite(v) ? v : 90;
-  } catch {
-    return 90;
-  }
+  } catch { return 90; }
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,6 +22,9 @@ export default defineConfig({
       },
     }),
   ],
+  server: {
+    proxy: { '/api': 'http://127.0.0.1:8787' },
+  },
   test: {
     environment: 'jsdom',
   },

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,3 @@
+name = "encar-api"
+main = "api/encar.ts"
+compatibility_date = "2024-08-01"


### PR DESCRIPTION
## Summary
- proxy `/api` to local worker in Vite for easier dev
- robust Encar worker with normalized URLs, proxy fallback and enhanced parsing
- resilient frontend calc handler with logging and default exchange rates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896e458c49c832492151fe5dd4ff6ee